### PR TITLE
Take Fastq as input

### DIFF
--- a/inputs.local.json
+++ b/inputs.local.json
@@ -1,6 +1,5 @@
 {
     "ChromoSeq.RunDir": "",
-    "ChromoSeq.FastqDir": "/scratch1/fs1/duncavagee/Chromoseq/demux_fastq",
     "ChromoSeq.SampleSheet": "",
     "ChromoSeq.Batch": "",
     "ChromoSeq.SeqDir": "/storage1/fs1/duncavagee/Active/SEQ/Chromoseq/output",


### PR DESCRIPTION
So this wdl workflow can use either RunDir/SampleSheet or FastqList as input. Also remove RunDir(if provided) after all tasks are done. There is also some code cleanup.